### PR TITLE
Adds a Snyk badge to show you are vulnerability-free

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # mdl-ext
+[![Known Vulnerabilities](https://snyk.io/test/github/benmag1/mdl-ext/badge.svg)](https://snyk.io/test/github/benmag1/mdl-ext)
 
 [![travis build](https://img.shields.io/travis/leifoolsen/mdl-ext.svg?style=flat-square)](https://travis-ci.org/leifoolsen/mdl-ext)
 [![codecov coverage](https://img.shields.io/codecov/c/github/leifoolsen/mdl-ext.svg?style=flat-square)](https://codecov.io/github/leifoolsen/mdl-ext)


### PR DESCRIPTION
mdl-ext has no vulnerabilities, which is awesome!

This PR adds a badge that shows that you're free of known vulnerabilities. Note that the badge works off the latest master branch.

Adding the badge will show others that you care about security, and that they should care too.
(It will also help to spread the word about Snyk, which would help us out!).

Check our [documentation](https://snyk.io/docs/badges/#github-badge?utm_source=gh_badge) if you'd like to know more about our badges.

Stay secure :-)
Ben from the Snyk team
<!--
snyk:metadata:
-->